### PR TITLE
Fix duplicate employees in task admin dropdown

### DIFF
--- a/employees/admin.py
+++ b/employees/admin.py
@@ -78,6 +78,13 @@ class TaskAdmin(admin.ModelAdmin):
         }),
     )
 
+    def render_change_form(self, request, context, *args, **kwargs):
+        # This is a fix for a UI bug where the 'assigned_to' dropdown shows
+        # duplicate employees. The root cause is unclear from the current codebase,
+        # but ensuring the queryset is distinct solves the immediate problem.
+        context['adminform'].form.fields['assigned_to'].queryset = Employee.objects.distinct()
+        return super().render_change_form(request, context, *args, **kwargs)
+
     def get_fieldsets(self, request, obj=None):
         fieldsets = super().get_fieldsets(request, obj)
         # Add other fields that are not explicitly in fieldsets, like 'order'


### PR DESCRIPTION
In the Django admin, when creating or editing a Task, the `assigned_to` dropdown was showing duplicate employee names if an employee was associated with multiple KPIs. This was confusing for the user.

This commit fixes the issue by overriding the `render_change_form` method in the `TaskAdmin` class. The method now explicitly sets the queryset for the `assigned_to` field to `Employee.objects.distinct()`, ensuring that each employee appears only once in the dropdown.

This commit also addresses the user's questions by confirming that this was a bug and clarifying that the `assigned_to` field is for the employee assigned to the task, not a manager.