### PR TITLE
Fix duplicate task lists and add validation

### DIFF
--- a/employees/models.py
+++ b/employees/models.py
@@ -267,7 +267,7 @@ class TaskList(models.Model):
         ordering = ['order']
 
     def __str__(self):
-        return self.name
+        return f"{self.name} ({self.board.employee.name})"
 
 class Task(models.Model):
     """A task (card) on a task list."""

--- a/employees/serializers.py
+++ b/employees/serializers.py
@@ -1,13 +1,28 @@
 from rest_framework import serializers
-from .models import WorkLog, Task, TaskList, TaskBoard
+from .models import Employee, WorkLog, Task, TaskList, TaskBoard
+
 
 class TaskSerializer(serializers.ModelSerializer):
     class Meta:
         model = Task
         fields = [
-            'id', 'title', 'description', 'order', 'due_date', 'list',
+            'id', 'title', 'description', 'order', 'due_date', 'list', 'assigned_to',
             'is_recurring', 'recurrence_frequency', 'recurrence_end_date'
         ]
+
+    def validate(self, data):
+        """
+        Check that the selected list belongs to the assigned employee.
+        """
+        task_list = data.get('list')
+        assigned_to = data.get('assigned_to')
+
+        if task_list and assigned_to:
+            if task_list.board.employee != assigned_to:
+                raise serializers.ValidationError(
+                    {'list': 'The selected list does not belong to the assigned employee.'}
+                )
+        return data
 
 class TaskListSerializer(serializers.ModelSerializer):
     tasks = TaskSerializer(many=True, read_only=True)


### PR DESCRIPTION
- Clarify the display name of TaskLists in dropdowns by including the employee's name in the `__str__` representation. This prevents confusion when multiple employees have lists with the same name.
- Add the `assigned_to` field to the TaskSerializer to allow assigning tasks to employees via the API.
- Add a validation rule to the TaskSerializer to ensure that the selected TaskList belongs to the employee assigned to the task, preventing data inconsistencies.