### PR TITLE
Feat: Add Employee Ranking and KPI Trend Charts

### DIFF
--- a/employees/api_urls.py
+++ b/employees/api_urls.py
@@ -1,6 +1,6 @@
 from django.urls import path, include
 from rest_framework.routers import DefaultRouter
-from .api_views import WorkLogViewSet, TaskBoardViewSet, TaskViewSet
+from .api_views import WorkLogViewSet, TaskBoardViewSet, TaskViewSet, kpi_history_api
 
 router = DefaultRouter()
 router.register(r'worklogs', WorkLogViewSet)
@@ -10,4 +10,5 @@ router.register(r'tasks', TaskViewSet)
 
 urlpatterns = [
     path('', include(router.urls)),
+    path('employees/<int:employee_id>/kpi-history/', kpi_history_api, name='kpi_history_api'),
 ]

--- a/employees/templates/employees/base.html
+++ b/employees/templates/employees/base.html
@@ -24,6 +24,9 @@
                 <li class="nav-item">
                     <a class="nav-link" href="{% url 'performance_report' %}">{% trans "Reports" %}</a>
                 </li>
+                <li class="nav-item">
+                    <a class="nav-link" href="{% url 'employee_ranking' %}">{% trans "Ranking" %}</a>
+                </li>
                 {% if user.is_superuser %}
                 <li class="nav-item">
                     <a class="nav-link" href="{% url 'company_settings' %}">{% trans "Settings" %}</a>
@@ -49,5 +52,7 @@
     <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/@popperjs/core@2.5.4/dist/umd/popper.min.js"></script>
     <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/js/bootstrap.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+    {% block javascript %}{% endblock %}
 </body>
 </html>

--- a/employees/templates/employees/employee_ranking.html
+++ b/employees/templates/employees/employee_ranking.html
@@ -1,0 +1,68 @@
+{% extends 'employees/base.html' %}
+{% load i18n %}
+
+{% block title %}{% trans "Employee Ranking" %}{% endblock %}
+
+{% block content %}
+<h1>{% trans "Employee Ranking" %}</h1>
+<p class="lead">{% trans "Select a KPI to see how employees stack up against each other." %}</p>
+
+<form method="get" class="form-inline mb-4">
+    <div class="form-group mr-2">
+        <label for="kpi" class="mr-2">{% trans "Select KPI" %}:</label>
+        <select name="kpi_id" id="kpi" class="form-control" onchange="this.form.submit()">
+            <option value="">--- {% trans "Choose a KPI" %} ---</option>
+            {% for kpi in all_kpis %}
+                <option value="{{ kpi.id }}" {% if kpi.id == selected_kpi_id %}selected{% endif %}>
+                    {{ kpi.name }}
+                </option>
+            {% endfor %}
+        </select>
+    </div>
+</form>
+
+{% if selected_kpi %}
+    <h2 class="mt-4">{% trans "Ranking for" %} "{{ selected_kpi.name }}"</h2>
+    <p>{% trans "Based on data from" %} {{ period }}</p>
+
+    {% if ranking_records %}
+        <table class="table table-striped table-hover">
+            <thead class="thead-dark">
+                <tr>
+                    <th style="width: 10%;">#</th>
+                    <th>{% trans "Employee" %}</th>
+                    <th style="width: 20%;">{{ selected_kpi.name }} {% if selected_kpi.measurement_type == 'percentage' %}(%){% endif %}</th>
+                </tr>
+            </thead>
+            <tbody>
+                {% for record in ranking_records %}
+                <tr {% if forloop.first %}class="table-success"{% endif %}>
+                    <td class="font-weight-bold">
+                        {% if forloop.first %}
+                            🥇 1
+                        {% elif forloop.counter == 2 %}
+                            🥈 2
+                        {% elif forloop.counter == 3 %}
+                            🥉 3
+                        {% else %}
+                            {{ forloop.counter }}
+                        {% endif %}
+                    </td>
+                    <td>{{ record.employee.name }}</td>
+                    <td>{{ record.actual_value|floatformat:2 }}</td>
+                </tr>
+                {% endfor %}
+            </tbody>
+        </table>
+    {% else %}
+        <div class="alert alert-info mt-4" role="alert">
+            {% trans "No performance data found for this KPI in the most recent period." %}
+        </div>
+    {% endif %}
+{% elif selected_kpi_id %}
+    <div class="alert alert-warning mt-4" role="alert">
+        {% trans "Please select a valid KPI." %}
+    </div>
+{% endif %}
+
+{% endblock %}

--- a/employees/templates/employees/performance_report.html
+++ b/employees/templates/employees/performance_report.html
@@ -57,4 +57,91 @@
     <p>{% trans "No performance records found for the selected employee." %}</p>
 {% endif %}
 
+{% if selected_employee_id %}
+<hr class="mt-5">
+<h2>{% trans "KPI Trend Charts" %}</h2>
+<div id="charts-container" class="mt-4">
+    {% if not records %}
+        <p>{% trans "No data available to display charts." %}</p>
+    {% else %}
+        <p>{% trans "Loading charts..." %}</p>
+    {% endif %}
+</div>
+{% endif %}
+
+{% endblock %}
+
+{% block javascript %}
+<script>
+document.addEventListener('DOMContentLoaded', function() {
+    const chartsContainer = document.getElementById('charts-container');
+    const selectedEmployeeId = {{ selected_employee_id|default:"null" }};
+
+    if (selectedEmployeeId && chartsContainer) {
+        const apiUrl = `/api/employees/${selectedEmployeeId}/kpi-history/`;
+
+        fetch(apiUrl)
+            .then(response => {
+                if (!response.ok) {
+                    throw new Error('Network response was not ok');
+                }
+                return response.json();
+            })
+            .then(kpiData => {
+                chartsContainer.innerHTML = ''; // Clear the 'Loading...' message
+
+                if (Object.keys(kpiData).length === 0) {
+                    chartsContainer.innerHTML = '<p>{% trans "No performance data available for charts." %}</p>';
+                    return;
+                }
+
+                for (const kpiName in kpiData) {
+                    if (kpiData.hasOwnProperty(kpiName)) {
+                        const chartData = kpiData[kpiName];
+
+                        // Create a container and canvas for each chart
+                        const chartWrapper = document.createElement('div');
+                        chartWrapper.className = 'mb-4';
+
+                        const chartTitle = document.createElement('h4');
+                        chartTitle.innerText = kpiName;
+
+                        const canvas = document.createElement('canvas');
+                        chartWrapper.appendChild(chartTitle);
+                        chartWrapper.appendChild(canvas);
+                        chartsContainer.appendChild(chartWrapper);
+
+                        // Render the chart
+                        new Chart(canvas, {
+                            type: 'line',
+                            data: {
+                                labels: chartData.labels,
+                                datasets: [{
+                                    label: kpiName,
+                                    data: chartData.data,
+                                    borderColor: 'rgba(75, 192, 192, 1)',
+                                    backgroundColor: 'rgba(75, 192, 192, 0.2)',
+                                    fill: true,
+                                    tension: 0.1
+                                }]
+                            },
+                            options: {
+                                responsive: true,
+                                scales: {
+                                    y: {
+                                        beginAtZero: false
+                                    }
+                                }
+                            }
+                        });
+                    }
+                }
+            })
+            .catch(error => {
+                console.error('Error fetching or parsing data:', error);
+                chartsContainer.innerHTML = '<p>{% trans "Could not load chart data." %}</p>';
+            });
+    }
+});
+</script>
 {% endblock %}

--- a/employees/urls.py
+++ b/employees/urls.py
@@ -10,6 +10,7 @@ urlpatterns = [
     path('employees/<int:employee_id>/salary/', views.employee_salary, name='employee_salary'),
     path('board/', views.task_board, name='task_board'),
     path('reports/', views.performance_report, name='performance_report'),
+    path('ranking/', views.employee_ranking, name='employee_ranking'),
     path('settings/', views.company_settings, name='company_settings'),
     path('login/', auth_views.LoginView.as_view(template_name='employees/login.html'), name='login'),
     path('logout/', auth_views.LogoutView.as_view(next_page='index'), name='logout'),


### PR DESCRIPTION
This commit introduces two major features to enhance data visualization and analysis capabilities: an employee ranking page and KPI trend charts on the performance report.

New Features:
- **Employee Ranking Page:** A new page at `/ranking/` allows managers to select a KPI and view a leaderboard of employees ranked by their performance for the most recent period. The top 3 performers are highlighted with medals to encourage friendly competition.
- **KPI Trend Charts:** The performance report page at `/reports/` is now enhanced with line charts. When an employee is selected, the page fetches the last 12 months of performance data and displays a trend chart for each KPI.

Technical Changes:
- Integrated `Chart.js` for data visualization.
- Added a new API endpoint `/api/employees/<id>/kpi-history/` to provide historical performance data.
- Created new views, URLs, and a template (`employee_ranking.html`) for the ranking feature.
- Updated the main navigation to include a link to the new Ranking page.