### PR TITLE
Fix login redirect URL

### DIFF
--- a/salary_management/settings.py
+++ b/salary_management/settings.py
@@ -135,6 +135,7 @@ STATIC_URL = "static/"
 DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
 
 LOGIN_URL = '/login/'
+LOGIN_REDIRECT_URL = '/'
 
 # Email settings for development (prints emails to console)
 EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'


### PR DESCRIPTION
The application was redirecting to the default `/accounts/profile/` URL after login, which does not exist, causing a 404 error.

This change sets the `LOGIN_REDIRECT_URL` to `/`, which is the application's home page, fixing the error.