### PR TITLE
This commit fixes an issue where the "Complete" and "Unfulfilled" but…

### DIFF
--- a/employees/templates/employees/task_board.html
+++ b/employees/templates/employees/task_board.html
@@ -147,12 +147,17 @@ document.addEventListener('DOMContentLoaded', function () {
         button.addEventListener('click', function() {
             const taskId = this.dataset.taskId;
             const url = `/api/tasks/${taskId}/mark_as_complete/`;
+            const employeeId = {{ selected_employee_id|default:"null" }};
+
             fetch(url, {
                 method: 'POST',
                 headers: {
                     'Content-Type': 'application/json',
                     'X-CSRFToken': '{{ csrf_token }}'
-                }
+                },
+                body: JSON.stringify({
+                    employee_id: employeeId
+                })
             }).then(() => location.reload());
         });
     });
@@ -161,12 +166,17 @@ document.addEventListener('DOMContentLoaded', function () {
         button.addEventListener('click', function() {
             const taskId = this.dataset.taskId;
             const url = `/api/tasks/${taskId}/mark_as_unfulfilled/`;
+            const employeeId = {{ selected_employee_id|default:"null" }};
+
             fetch(url, {
                 method: 'POST',
                 headers: {
                     'Content-Type': 'application/json',
                     'X-CSRFToken': '{{ csrf_token }}'
-                }
+                },
+                body: JSON.stringify({
+                    employee_id: employeeId
+                })
             }).then(() => location.reload());
         });
     });


### PR DESCRIPTION
…tons on the task board were not functional for superusers managing an employee's board.

The key changes are:
- The `TaskViewSet`'s `get_queryset` method is updated to return all tasks for superusers, allowing them to modify any task.
- The frontend JavaScript now sends the `employee_id` in the request body when a superuser clicks the "Complete" or "Unfulfilled" buttons.
- The `mark_as_complete` and `mark_as_unfulfilled` API views now use this `employee_id` to correctly identify the employee and trigger their bonus recalculation. This ensures that the bonus logic is applied correctly when a superuser manages tasks on behalf of another employee.