### PR TITLE
feat: Filter inactive employees from task assignment

### DIFF
--- a/employees/serializers.py
+++ b/employees/serializers.py
@@ -3,6 +3,10 @@ from .models import Employee, WorkLog, Task, TaskList, TaskBoard
 
 
 class TaskSerializer(serializers.ModelSerializer):
+    assigned_to = serializers.PrimaryKeyRelatedField(
+        queryset=Employee.objects.filter(end_date__isnull=True)
+    )
+
     class Meta:
         model = Task
         fields = [


### PR DESCRIPTION
Modified the TaskSerializer to exclude employees with a contract end_date from the 'assigned_to' field. This prevents terminated employees from being assigned new tasks.

- Updated TaskSerializer to use a PrimaryKeyRelatedField for 'assigned_to' with a queryset that only includes active employees.
- Added a test case to verify that assigning a task to an inactive employee fails with a validation error.
- Corrected the test to account for translated error messages.