### PR TITLE
feat: Add favicon support from admin

### DIFF
--- a/employees/templates/employees/base.html
+++ b/employees/templates/employees/base.html
@@ -5,6 +5,10 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>{% block title %}{% trans "Salary Management" %}{% endblock %}</title>
+    {% if site_config.favicon %}
+    <link rel="icon" href="{{ site_config.favicon.url }}" type="image/x-icon">
+    <link rel="shortcut icon" href="{{ site_config.favicon.url }}" type="image/x-icon">
+    {% endif %}
     <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css">
 </head>
 <body>


### PR DESCRIPTION
This change resolves an issue where a user-uploaded favicon was not being displayed.

The solution involves:
- A new `SiteConfiguration` model to allow uploading a favicon via the Django admin panel.
- A context processor that makes the `site_config` object available to all templates.
- An update to the `base.html` template to include a `<link>` tag that points to the uploaded favicon's URL.

This approach allows administrators to easily manage the site's favicon directly from the admin interface without requiring code changes.