### PR TITLE
Fix TypeError when creating recurring tasks.

### DIFF
--- a/employees/signals.py
+++ b/employees/signals.py
@@ -29,7 +29,7 @@ def handle_recurring_task(sender, instance, created, **kwargs):
     elif instance.recurrence_frequency == 'yearly':
         next_due_date = instance.due_date + relativedelta(years=1)
 
-    if not next_due_date or (instance.recurrence_end_date and next_due_date > instance.recurrence_end_date):
+    if not next_due_date or (instance.recurrence_end_date and next_due_date.date() > instance.recurrence_end_date):
         return
 
     try:


### PR DESCRIPTION
The application was raising a `TypeError: can't compare datetime.datetime to datetime.date` in the `handle_recurring_task` signal. This occurred because `next_due_date` (a `datetime` object) was being compared directly with `recurrence_end_date` (a `date` object).

This commit resolves the issue by converting `next_due_date` to a `date` object using `.date()` before the comparison, ensuring that the types are compatible.