### PR TITLE
Fix(tasks): Correctly display and handle recurring tasks on board

### DIFF
--- a/employees/templates/employees/task_board.html
+++ b/employees/templates/employees/task_board.html
@@ -76,21 +76,21 @@
         <div class="task-list-header">{{ list.name }}</div>
         <div class="list-cards" data-list-id="{{ list.id }}">
             {% for task in list.tasks.all %}
-            <div class="task-card" data-task-id="{{ task.id }}">
-                {{ task.title }}
-                <div class="task-due-date">
-                    {% if task.due_date %}
-                        {{ task.due_date|date:"Y-m-d H:i" }}
-                    {% endif %}
-                </div>
-                <span class="task-status status-{{ task.status }}">{{ task.get_status_display }}</span>
-                {% if user.is_superuser %}
-                <div>
-                    <button class="btn btn-sm btn-success complete-btn" data-task-id="{{ task.id }}">{% trans "Complete" %}</button>
-                    <button class="btn btn-sm btn-danger unfulfilled-btn" data-task-id="{{ task.id }}">{% trans "Unfulfilled" %}</button>
+                {% if not task.is_recurring %}
+                <div class="task-card" data-task-id="{{ task.id }}">
+                    {{ task.title }}
+                    <div class="task-due-date">
+                        {% if task.due_date %}
+                            <strong>{% trans "Due:" %}</strong> {{ task.due_date|date:"Y-m-d H:i" }}
+                        {% endif %}
+                    </div>
+                    <span class="task-status status-{{ task.status }}">{{ task.get_status_display }}</span>
+                    <div>
+                        <button class="btn btn-sm btn-success complete-btn" data-task-id="{{ task.id }}">{% trans "Complete" %}</button>
+                        <button class="btn btn-sm btn-danger unfulfilled-btn" data-task-id="{{ task.id }}">{% trans "Unfulfilled" %}</button>
+                    </div>
                 </div>
                 {% endif %}
-            </div>
             {% endfor %}
         </div>
     </div>


### PR DESCRIPTION
This commit resolves an issue where recurring task instances were not being displayed or handled correctly on the task board.

The key changes are:
1.  **Template Update (`task_board.html`):**
    - The template now filters out the main recurring "template" tasks and only displays the individual instances (`is_recurring=False`).
    - The due date for each task is now explicitly shown to help distinguish between different instances of a recurring task.
    - The "Complete" and "Unfulfilled" buttons are now visible to all users, relying on backend API permissions for authorization.

2.  **API Logic (`api_views.py`):**
    - When an instance of a recurring task is marked as complete, the API now correctly generates the next task in the series.
    - The permissions for `mark_as_complete` and `mark_as_unfulfilled` have been updated to allow users to modify their own assigned tasks, not just superusers.