### PR TITLE
Fix(api): Register API URLs to resolve 404 errors

### DIFF
--- a/salary_management/urls.py
+++ b/salary_management/urls.py
@@ -22,6 +22,7 @@ from django.conf.urls.static import static
 
 urlpatterns = [
     path("admin/", admin.site.urls),
+    path("api/", include("employees.api_urls")),
     path("", include("employees.urls")),
     path("caldav/", include("caldav.urls")),
 ]


### PR DESCRIPTION
This commit fixes a bug where API endpoints for tasks, such as 'mark_as_unfulfilled', were returning a 404 Not Found error.

The root cause was that the API URL configuration defined in `employees/api_urls.py` was not being included in the main project `urls.py`. This meant that none of the API routes were registered with the Django application.

The fix involves adding the following line to `salary_management/urls.py`: `path("api/", include("employees.api_urls"))`

This makes all task-related API endpoints available under the `/api/` prefix, resolving the routing issue and allowing the frontend to communicate with the backend as intended.