### PR TITLE
Fix(tasks): Restrict task completion actions to superusers

### DIFF
--- a/employees/api_views.py
+++ b/employees/api_views.py
@@ -146,9 +146,9 @@ class TaskViewSet(viewsets.ModelViewSet):
         """
         task = self.get_object()
 
-        # A user can only complete their own tasks, unless they are a superuser.
-        if not request.user.is_superuser and task.assigned_to.user != request.user:
-            return Response({"error": "You do not have permission to modify this task."}, status=status.HTTP_403_FORBIDDEN)
+        # Only superusers can mark tasks as complete.
+        if not request.user.is_superuser:
+            return Response({"error": "You do not have permission to perform this action."}, status=status.HTTP_403_FORBIDDEN)
 
         from datetime import datetime
         from .models import TaskList
@@ -209,9 +209,9 @@ class TaskViewSet(viewsets.ModelViewSet):
         """Mark a task as unfulfilled and move it to the 'Pendiente' list."""
         task = self.get_object()
 
-        # A user can only un-fulfill their own tasks, unless they are a superuser.
-        if not request.user.is_superuser and task.assigned_to.user != request.user:
-            return Response({"error": "You do not have permission to modify this task."}, status=status.HTTP_403_FORBIDDEN)
+        # Only superusers can mark tasks as un-fulfilled.
+        if not request.user.is_superuser:
+            return Response({"error": "You do not have permission to perform this action."}, status=status.HTTP_403_FORBIDDEN)
 
         from .models import TaskList
         task.status = 'unfulfilled'

--- a/employees/templates/employees/task_board.html
+++ b/employees/templates/employees/task_board.html
@@ -85,10 +85,12 @@
                         {% endif %}
                     </div>
                     <span class="task-status status-{{ task.status }}">{{ task.get_status_display }}</span>
+                    {% if user.is_superuser %}
                     <div>
                         <button class="btn btn-sm btn-success complete-btn" data-task-id="{{ task.id }}">{% trans "Complete" %}</button>
                         <button class="btn btn-sm btn-danger unfulfilled-btn" data-task-id="{{ task.id }}">{% trans "Unfulfilled" %}</button>
                     </div>
+                    {% endif %}
                 </div>
                 {% endif %}
             {% endfor %}


### PR DESCRIPTION
This commit corrects a regression where the ability to mark tasks as complete or unfulfilled was unintentionally made available to non-superuser roles.

The following changes have been made to enforce the business rule that only superusers can change the status of tasks:

1.  **Template (`task_board.html`):** The "Complete" and "Unfulfilled" buttons are now wrapped in an `{% if user.is_superuser %}` block, ensuring they are only visible to superusers.

2.  **API (`api_views.py`):** The `mark_as_complete` and `mark_as_unfulfilled` actions have been updated with a `if not request.user.is_superuser:` check. This provides backend security to prevent unauthorized users from changing task statuses via direct API calls.

This ensures that the task completion functionality is restricted to authorized users, both on the frontend and backend.