### PR TITLE
Fix new employees being created as inactive

### DIFF
--- a/employees/admin.py
+++ b/employees/admin.py
@@ -30,8 +30,23 @@ class SiteConfigurationAdmin(admin.ModelAdmin):
 
 @admin.register(Employee)
 class EmployeeAdmin(admin.ModelAdmin):
-    list_display = ('name', 'email', 'hire_date')
+    list_display = ('name', 'email', 'hire_date', 'end_date', 'is_active_status')
     search_fields = ('name', 'email')
+    list_filter = ('end_date',)
+
+    @admin.display(boolean=True, description='Active')
+    def is_active_status(self, obj):
+        return obj.is_active
+
+    def save_model(self, request, obj, form, change):
+        """
+        When creating a new employee, ensure the end_date is None unless a value
+        is explicitly provided. This prevents incorrect database-level defaults
+        from making new employees inactive.
+        """
+        if not change and not form.cleaned_data.get('end_date'):
+            obj.end_date = None
+        super().save_model(request, obj, form, change)
 
 @admin.register(Salary)
 class SalaryAdmin(admin.ModelAdmin):

--- a/employees/models.py
+++ b/employees/models.py
@@ -16,6 +16,11 @@ class Employee(models.Model):
     def __str__(self):
         return self.name
 
+    @property
+    def is_active(self):
+        """Returns True if the employee is currently active."""
+        return self.end_date is None
+
     def calculate_ipac(self, year, month):
         """
         Calculates the Quality-Adjusted Productivity Index (IPAC) for a given month.

--- a/employees/views.py
+++ b/employees/views.py
@@ -316,10 +316,14 @@ def terminate_employee(request, employee_id):
     if request.method == 'POST':
         try:
             employee = Employee.objects.get(pk=employee_id)
-            employee.end_date = date.today()
-            employee.save()
-            messages.success(request, f"The contract for {employee.name} has been terminated.")
+            # Use the is_active property to prevent terminating an already inactive employee
+            if employee.is_active:
+                employee.end_date = date.today()
+                employee.save()
+                messages.success(request, f"El contrato de {employee.name} ha sido terminado.")
+            else:
+                messages.warning(request, f"{employee.name} ya se encuentra inactivo.")
         except Employee.DoesNotExist:
-            messages.error(request, "Employee not found.")
+            messages.error(request, "Empleado no encontrado.")
 
     return redirect('employee_list')


### PR DESCRIPTION
New employees were being created with a non-null `end_date`, which caused them to be considered inactive. This meant they would not appear on the main employee list or be available for task assignments.

This commit resolves the issue by:
1.  Adding an `is_active` property to the `Employee` model for clearer and more consistent status checks.
2.  Modifying the `EmployeeAdmin` to explicitly set the `end_date` to `None` upon creation, ensuring new employees are active by default.
3.  Updating the `terminate_employee` view to use the new `is_active` property, preventing redundant actions and providing clearer user feedback in Spanish.
4.  Enhancing the `EmployeeAdmin` list view to display the employee's active status, improving administrative oversight.